### PR TITLE
Remove quantile config option

### DIFF
--- a/tabpfn_time_series/predictor.py
+++ b/tabpfn_time_series/predictor.py
@@ -4,10 +4,7 @@ from enum import Enum
 from autogluon.timeseries import TimeSeriesDataFrame
 
 from tabpfn_time_series.tabpfn_worker import TabPFNClient, LocalTabPFN, MockTabPFN
-from tabpfn_time_series.defaults import (
-    TABPFN_TS_DEFAULT_QUANTILE_CONFIG,
-    TABPFN_TS_DEFAULT_CONFIG,
-)
+from tabpfn_time_series.defaults import TABPFN_TS_DEFAULT_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +36,6 @@ class TabPFNTimeSeriesPredictor:
         self,
         train_tsdf: TimeSeriesDataFrame,  # with features and target
         test_tsdf: TimeSeriesDataFrame,  # with features only
-        quantile_config: list[float] = TABPFN_TS_DEFAULT_QUANTILE_CONFIG,
     ) -> TimeSeriesDataFrame:
         """
         Predict on each time series individually (local forecasting).
@@ -49,4 +45,4 @@ class TabPFNTimeSeriesPredictor:
             f"Predicting {len(train_tsdf.item_ids)} time series with config{self.tabpfn_worker.config}"
         )
 
-        return self.tabpfn_worker.predict(train_tsdf, test_tsdf, quantile_config)
+        return self.tabpfn_worker.predict(train_tsdf, test_tsdf)


### PR DESCRIPTION
### Development
- remove the option to ask for specific quantile config (only provide the standard `[0.1, 0.2, ..., 0.9]` for now)
- **rationale:** simpler and more robust implementation, doesn't lose much use case too.