### PR TITLE
Remove pip cache

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,14 +51,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 


### PR DESCRIPTION
## Development
- remove (obsolete) pip caching for github action since we have moved to UV
- also, we don't need to explicitly set cache for UV since it's enabled by default (https://github.com/astral-sh/setup-uv?tab=readme-ov-file#enable-caching)