### PR TITLE
Add tests for prediction with the local tabpfn package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "pyyaml>=6.0.1",
     "backoff>=2.2.1",
-    "tabpfn-common-utils[telemetry-interactive]>=0.2.2"
+    "tabpfn-common-utils[telemetry-interactive]>=0.2.2",
 ]
 
 
@@ -58,3 +58,6 @@ dev = [
 [project.urls]
 "Homepage" = "https://github.com/liam-sbhoo/tabpfn-time-series"
 "Bug Tracker" = "https://github.com/liam-sbhoo/tabpfn-time-series/issues"
+
+[tool.pytest.ini_options]
+markers = ["uses_tabpfn_client: These tests require a TabPFN API key."]

--- a/tabpfn_time_series/predictor.py
+++ b/tabpfn_time_series/predictor.py
@@ -68,8 +68,10 @@ class TimeSeriesPredictor:
             )
 
             worker_class = TabPFNClientCPUParallelWorker
-        elif tabpfn_class == TabPFNRegressor:
+        elif tabpfn_class == TabPFNRegressor and torch.cuda.is_available():
             worker_class = GPUParallelWorker
+        elif tabpfn_class == TabPFNRegressor and not torch.cuda.is_available():
+            worker_class = CPUParallelWorker
         else:
             raise ValueError(f"Expected TabPFN-family regressor, got {tabpfn_class}")
 


### PR DESCRIPTION
Current tests only cover the client.

Also add a "uses_tabpfn_client" marker to allow disabling the client tests. We want this so we can run the tests in this repo from the tabpfn repo, without also running the client tests.

To achieve the above:
- Update TimeSeriesPredictor.from_tabpfn_family() to support CPU inference. Unsure if this is a good idea? Could make it clear that its for test only.
- Switch from unittest to pytest style, as this is what the CI and test_freq_alias appear to use, and what we use in our other repos
- Tweak CI workflow

Part of PRI-97