### PR TITLE
Bugfix - instable scipy detrend

### DIFF
--- a/tabpfn_time_series/features/auto_features.py
+++ b/tabpfn_time_series/features/auto_features.py
@@ -302,7 +302,7 @@ def detrend(
         # Use numpy polyfit instead of scipy.signal.detrend for numerical stability
         # (scipy's implementation can cause overflow/divide-by-zero on Apple Silicon)
         indices = np.arange(len(x))
-        coeffs = np.polyfit(indices, x, 1)
+        coeffs = np.polyfit(indices, x, 1, rcond=None)
         trend = np.polyval(coeffs, indices)
         return x - trend
 


### PR DESCRIPTION
## PR Summary: Fix scipy detrend numerical warnings

**Problem:**
- `RuntimeWarning: divide by zero / overflow / invalid value encountered in matmul` during `AutoSeasonalFeature` detrending
- Caused by scipy's `signal.detrend` numerical instabilities, particularly on Apple Silicon with Accelerate framework

**Solution:**
- Replace `scipy.signal.detrend` with numpy-based implementations:
  - `linear`: Use `np.polyfit` + `np.polyval` (SVD-based, more numerically stable)
  - `constant`: Use `np.mean` subtraction
- Mathematically equivalent
- No more warning
