### PR TITLE
Remove locked option from uv sync command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,7 +53,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install the project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --all-extras --dev
 
       - name: Run Tests
         env:


### PR DESCRIPTION
## Development
The `--lock` option is blocking the `uv` when changes are added to the dependency (`pyproject.toml`).