### PR TITLE
Fix typo in inference options description in QuickStart Notebook

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "We'll import the library and initialize the forecasting pipeline. Here, we provide **two inference options:**\n",
     "- `TabPFNMode.LOCAL` -- Run on your machine (requires GPU for speed)\n",
-    "- `TabPNFMode.CLIENT` -- Use our free cloud API (recommended if no GPU)\n",
+    "- `TabPFNMode.CLIENT` -- Use our free cloud API (recommended if no GPU)\n",
     "\n",
     "> *Note: When using `TabPFNMode.CLIENT`, you'll be prompted to login/create an account.*"
    ]


### PR DESCRIPTION
For using the free cloud API for inference, the notebook mentions TabPNFMode.CLIENT instead of TabPFNMode.CLIENT. It is used correctly in the following note.