### PR TITLE
Refactor feature transformation logic in FeatureTransformer

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,4 +59,4 @@ jobs:
         env:
           TABPFN_CLIENT_API_KEY: ${{ secrets.TABPFN_CLIENT_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: uv run pytest tests
+        run: uv run pytest tests -m "not uses_tabpfn_client"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: In pull request
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - beta
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout PR code safely
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
       - name: Ruff Linting
         uses: astral-sh/ruff-action@v3
         with:
@@ -36,6 +40,10 @@ jobs:
     steps:
       - name: Checkout PR code safely
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -51,4 +59,4 @@ jobs:
         env:
           TABPFN_CLIENT_API_KEY: ${{ secrets.TABPFN_CLIENT_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: uv run pytest tests -m "not uses_tabpfn_client"
+        run: uv run pytest tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: In pull request
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - beta
@@ -13,10 +13,6 @@ jobs:
     steps:
       - name: Checkout PR code safely
         uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-
       - name: Ruff Linting
         uses: astral-sh/ruff-action@v3
         with:
@@ -40,10 +36,6 @@ jobs:
     steps:
       - name: Checkout PR code safely
         uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/tabpfn_time_series/features/feature_transformer.py
+++ b/tabpfn_time_series/features/feature_transformer.py
@@ -24,18 +24,28 @@ class FeatureTransformer:
 
         static_features = train_tsdf.static_features
 
-        tsdf = pd.concat([train_tsdf, test_tsdf])
+        item_ids = train_tsdf.index.get_level_values("item_id").unique()
 
-        # Apply all feature generators
+        # Tag before concat so we can split correctly after per-series reordering.
+        tsdf = pd.concat(
+            [
+                train_tsdf.assign(_is_train=True),
+                test_tsdf.assign(_is_train=False),
+            ]
+        )
+
         for generator in self.feature_generators:
-            tsdf = generator(tsdf)
+            per_series = [
+                generator(tsdf.xs(item_id, level="item_id")) for item_id in item_ids
+            ]
+            tsdf = pd.concat(per_series, keys=item_ids, names=["item_id"])
 
-        # Split train and test tsdf
-        train_slice = tsdf.iloc[: len(train_tsdf)]
-        test_slice = tsdf.iloc[len(train_tsdf) :]
+        # Split by tag (not iloc) since per-series concat reorders rows by item_id
+        train_slice = tsdf[tsdf["_is_train"]].drop(columns=["_is_train"])
+        test_slice = tsdf[~tsdf["_is_train"]].drop(columns=["_is_train"])
 
-        # Convert back to TimeSeriesDataFrame and re-attach static features
-        # This ensures the metadata remains intact even if generators returned a standard DF
+        # Re-cast to TimeSeriesDataFrame and re-attach static_features,
+        # since concat/slicing may have stripped the subclass and its metadata.
         train_tsdf = TimeSeriesDataFrame(train_slice, static_features=static_features)
         test_tsdf = TimeSeriesDataFrame(test_slice, static_features=static_features)
 

--- a/tabpfn_time_series/features/feature_transformer.py
+++ b/tabpfn_time_series/features/feature_transformer.py
@@ -3,9 +3,7 @@ from typing import List, Tuple
 import pandas as pd
 
 from tabpfn_time_series.ts_dataframe import TimeSeriesDataFrame
-from tabpfn_time_series.features.feature_generator_base import (
-    FeatureGenerator,
-)
+from tabpfn_time_series.features.feature_generator_base import FeatureGenerator
 
 
 class FeatureTransformer:
@@ -22,15 +20,13 @@ class FeatureTransformer:
 
         self._validate_input(train_tsdf, test_tsdf, target_column)
 
-        static_features = train_tsdf.static_features
-
-        # Tag before concat so we can split correctly after per-series reordering.
-        tsdf = pd.concat(
-            [
-                train_tsdf.assign(_is_train=True),
-                test_tsdf.assign(_is_train=False),
-            ]
+        static_features = self._merge_static_features(
+            train_tsdf.static_features, test_tsdf.static_features
         )
+
+        train_plain = pd.DataFrame(train_tsdf).assign(_is_train=True)
+        test_plain = pd.DataFrame(test_tsdf).assign(_is_train=False)
+        tsdf = pd.concat([train_plain, test_plain])
 
         item_ids = tsdf.index.get_level_values("item_id").unique()
 
@@ -46,10 +42,12 @@ class FeatureTransformer:
         train_slice = tsdf[tsdf["_is_train"]].drop(columns=["_is_train"])
         test_slice = tsdf[~tsdf["_is_train"]].drop(columns=["_is_train"])
 
-        # Re-cast to TimeSeriesDataFrame and re-attach static_features since
-        # concat/slicing strips the subclass and its metadata.
-        train_tsdf = TimeSeriesDataFrame(train_slice, static_features=static_features)
-        test_tsdf = TimeSeriesDataFrame(test_slice, static_features=static_features)
+        train_tsdf = TimeSeriesDataFrame(
+            pd.DataFrame(train_slice), static_features=static_features
+        )
+        test_tsdf = TimeSeriesDataFrame(
+            pd.DataFrame(test_slice), static_features=static_features
+        )
 
         assert not train_tsdf[target_column].isna().any(), (
             "All target values in train_tsdf should be non-NaN"
@@ -57,6 +55,21 @@ class FeatureTransformer:
         assert test_tsdf[target_column].isna().all()
 
         return train_tsdf, test_tsdf
+
+    @staticmethod
+    def _merge_static_features(
+        train_static: pd.DataFrame | None,
+        test_static: pd.DataFrame | None,
+    ) -> pd.DataFrame | None:
+        """Return static features covering all item_ids from both train and test."""
+        if train_static is None:
+            return None
+        if test_static is None:
+            return train_static
+        new_items = test_static.index.difference(train_static.index)
+        if len(new_items) == 0:
+            return train_static
+        return pd.concat([train_static, test_static.loc[new_items]])
 
     @staticmethod
     def _validate_input(

--- a/tabpfn_time_series/features/feature_transformer.py
+++ b/tabpfn_time_series/features/feature_transformer.py
@@ -24,8 +24,6 @@ class FeatureTransformer:
 
         static_features = train_tsdf.static_features
 
-        item_ids = train_tsdf.index.get_level_values("item_id").unique()
-
         # Tag before concat so we can split correctly after per-series reordering.
         tsdf = pd.concat(
             [
@@ -34,18 +32,22 @@ class FeatureTransformer:
             ]
         )
 
-        for generator in self.feature_generators:
-            per_series = [
-                generator(tsdf.xs(item_id, level="item_id")) for item_id in item_ids
-            ]
-            tsdf = pd.concat(per_series, keys=item_ids, names=["item_id"])
+        item_ids = tsdf.index.get_level_values("item_id").unique()
 
-        # Split by tag (not iloc) since per-series concat reorders rows by item_id
+        processed_series = []
+        for item_id in item_ids:
+            series_df = tsdf.xs(item_id, level="item_id")
+            for generator in self.feature_generators:
+                series_df = generator(series_df)
+            processed_series.append(series_df)
+        tsdf = pd.concat(processed_series, keys=item_ids, names=["item_id"])
+
+        # Split by tag (not iloc) since per-series concat reorders rows by item_id.
         train_slice = tsdf[tsdf["_is_train"]].drop(columns=["_is_train"])
         test_slice = tsdf[~tsdf["_is_train"]].drop(columns=["_is_train"])
 
-        # Re-cast to TimeSeriesDataFrame and re-attach static_features,
-        # since concat/slicing may have stripped the subclass and its metadata.
+        # Re-cast to TimeSeriesDataFrame and re-attach static_features since
+        # concat/slicing strips the subclass and its metadata.
         train_tsdf = TimeSeriesDataFrame(train_slice, static_features=static_features)
         test_tsdf = TimeSeriesDataFrame(test_slice, static_features=static_features)
 


### PR DESCRIPTION
## Fix per-series feature generation regression introduced in 1.0.9

### Problem

Version 1.0.9 inadvertently broke per-series feature generation while fixing a `static_features` metadata crash. The fix replaced:

```python
# 1.0.8 — correct: runs generator independently per item_id
tsdf = tsdf.groupby(level="item_id", group_keys=False).apply(generator)
```

with:

```python
# 1.0.9 — broken: runs generator on the full concatenated dataframe
tsdf = generator(tsdf)
```

This causes features (lags, rolling statistics, trends) to be computed across series boundaries, producing wrong values and significantly degraded predictions.

### Root Cause

The original `groupby().apply()` was intentional — it ensured each generator ran per `item_id`. The 1.0.9 fix removed it entirely to avoid AutoGluon's `__finalize__` scrambling the index during `.apply()` and losing `static_features` metadata, but this broke the per-series semantics.

### Fix

Loop over each series explicitly, applying all generators before moving to the next, then concat once:

```python
processed_series = []
for item_id in item_ids:
    series_df = tsdf.xs(item_id, level="item_id")
    for generator in self.feature_generators:
        series_df = generator(series_df)
    processed_series.append(series_df)
tsdf = pd.concat(processed_series, keys=item_ids, names=["item_id"])
```

Additional details:
- `item_ids` is extracted from the combined `tsdf` (after concat of train and test) to avoid dropping items present only in `test_tsdf`
- `tsdf.xs(item_id, level="item_id")` slices correctly even when `item_id` is not the outermost index level
- `pd.concat(..., keys=item_ids, names=["item_id"])` explicitly rebuilds the MultiIndex
- A `_is_train` marker column splits train/test after the loop, since per-series concat reorders rows by `item_id`, making positional `iloc` splits unreliable
- `static_features` are saved before the loop and re-attached via `TimeSeriesDataFrame(..., static_features=static_features)`
- Single `pd.concat` at the end is more efficient than one concat per generator

### Result

Prediction quality is restored to 1.0.8 levels. The `static_features` metadata crash remains fixed.
<img width="2084" height="1475" alt="image" src="https://github.com/user-attachments/assets/598a145b-6c23-496d-bff5-99d5c6ea4988" />
