### PR TITLE
Add `devices` parameter for GPU device selection

### DIFF
--- a/tabpfn_time_series/pipeline.py
+++ b/tabpfn_time_series/pipeline.py
@@ -215,6 +215,7 @@ class TabPFNTSPipeline:
         tabpfn_mode: TabPFNMode = TabPFNMode.CLIENT,
         tabpfn_output_selection: Literal["mean", "median", "mode"] = "median",
         tabpfn_model_config: dict = TABPFN_DEFAULT_CONFIG,
+        devices: list[int] | None = None,
     ):
         """
         Initialize the TabPFN-TS forecasting pipeline.
@@ -234,6 +235,10 @@ class TabPFNTSPipeline:
                 Options: "mean", "median", "mode". Default: "median".
             tabpfn_model_config: Configuration dictionary for the TabPFN model.
                 See TABPFN_DEFAULT_CONFIG for default settings.
+            devices: List of GPU device indices to use for local inference
+                (e.g. [2, 3] to run on GPUs 2 and 3). Only used when
+                tabpfn_mode is LOCAL with CUDA available. If None, uses all
+                available GPUs.
 
         Note:
             - When using TabPFNMode.CLIENT, you'll be prompted to login or create an account
@@ -244,6 +249,16 @@ class TabPFNTSPipeline:
         from tabpfn_client import TabPFNRegressor as TabPFNClientRegressor
 
         self.max_context_length = max_context_length
+
+        if devices is not None and tabpfn_mode != TabPFNMode.LOCAL:
+            raise ValueError(
+                "The 'devices' parameter is only supported with tabpfn_mode=TabPFNMode.LOCAL"
+            )
+
+        worker_kwargs = {}
+        if devices is not None:
+            worker_kwargs["devices"] = devices
+
         self.predictor = TimeSeriesPredictor.from_tabpfn_family(
             tabpfn_class=(
                 TabPFNClientRegressor
@@ -252,6 +267,7 @@ class TabPFNTSPipeline:
             ),
             tabpfn_config=tabpfn_model_config,
             tabpfn_output_selection=tabpfn_output_selection,
+            worker_kwargs=worker_kwargs,
         )
         self.feature_transformer = FeatureTransformer(temporal_features)
 

--- a/tabpfn_time_series/predictor.py
+++ b/tabpfn_time_series/predictor.py
@@ -51,6 +51,7 @@ class TimeSeriesPredictor:
         tabpfn_class: Type[RegressorMixin],
         tabpfn_config: Dict[str, Any] = {},
         tabpfn_output_selection: str = "median",  # mean or median
+        worker_kwargs: Dict[str, Any] | None = None,
     ):
         from tabpfn import TabPFNRegressor
         from tabpfn_client import TabPFNRegressor as TabPFNClientRegressor
@@ -75,7 +76,11 @@ class TimeSeriesPredictor:
         else:
             raise ValueError(f"Expected TabPFN-family regressor, got {tabpfn_class}")
 
-        return cls(model_adapter=model_adapter, worker_class=worker_class)
+        return cls(
+            model_adapter=model_adapter,
+            worker_class=worker_class,
+            worker_kwargs=worker_kwargs or {},
+        )
 
     @classmethod
     def from_point_prediction_regressor(

--- a/tabpfn_time_series/worker/parallel_workers/gpu_worker.py
+++ b/tabpfn_time_series/worker/parallel_workers/gpu_worker.py
@@ -19,25 +19,36 @@ class GPUParallelWorker(ParallelWorker):
         inference_routine: Callable,
         num_gpus: int = None,
         num_workers_per_gpu: int = 1,
+        devices: list[int] | None = None,
     ):
         """Initialize GPU parallel worker.
 
         Args:
             inference_routine: Callable that performs inference on a single time series
-            num_gpus: Number of GPUs to use (default: all available)
+            num_gpus: Number of GPUs to use (default: all available).
+                Ignored if `devices` is provided.
             num_workers_per_gpu: Number of workers per GPU (default: 1)
+            devices: Explicit list of GPU device indices to use (e.g. [2, 3]).
+                If provided, overrides `num_gpus`. If None, uses devices
+                0 through num_gpus-1.
 
         Raises:
             ValueError: If GPU is not available
         """
         super().__init__(inference_routine)
 
-        self.num_gpus = num_gpus or torch.cuda.device_count()
-        self.num_workers_per_gpu = num_workers_per_gpu
-        self.total_num_workers = self.num_gpus * self.num_workers_per_gpu
-
         if not torch.cuda.is_available():
             raise ValueError("GPU is required for GPU parallel inference")
+
+        if devices is not None:
+            self.devices = list(devices)
+        else:
+            num_gpus = num_gpus or torch.cuda.device_count()
+            self.devices = list(range(num_gpus))
+
+        self.num_gpus = len(self.devices)
+        self.num_workers_per_gpu = num_workers_per_gpu
+        self.total_num_workers = self.num_gpus * self.num_workers_per_gpu
 
     def predict(
         self,
@@ -62,7 +73,7 @@ class GPUParallelWorker(ParallelWorker):
             predictions = self._prediction_routine_per_gpu(
                 train_tsdf,
                 test_tsdf,
-                gpu_id=0,
+                gpu_id=self.devices[0],
                 **kwargs,
             )
             return TimeSeriesDataFrame(predictions)
@@ -85,7 +96,7 @@ class GPUParallelWorker(ParallelWorker):
             delayed(self._prediction_routine_per_gpu)(
                 train_tsdf.loc[chunk],
                 test_tsdf.loc[chunk],
-                gpu_id=i % self.num_gpus,  # Alternate between available GPUs
+                gpu_id=self.devices[i % self.num_gpus],  # Alternate between available GPUs
             )
             for i, chunk in enumerate(item_ids_chunks)
         )

--- a/tabpfn_time_series/worker/parallel_workers/gpu_worker.py
+++ b/tabpfn_time_series/worker/parallel_workers/gpu_worker.py
@@ -96,7 +96,9 @@ class GPUParallelWorker(ParallelWorker):
             delayed(self._prediction_routine_per_gpu)(
                 train_tsdf.loc[chunk],
                 test_tsdf.loc[chunk],
-                gpu_id=self.devices[i % self.num_gpus],  # Alternate between available GPUs
+                gpu_id=self.devices[
+                    i % self.num_gpus
+                ],  # Alternate between available GPUs
             )
             for i, chunk in enumerate(item_ids_chunks)
         )


### PR DESCRIPTION
## Summary
- Add `devices: list[int] | None` parameter to `GPUParallelWorker`, `TimeSeriesPredictor.from_tabpfn_family`, and `TabPFNTSPipeline`
- Allows callers to specify which GPU devices to use (e.g. `devices=[2, 3]`) instead of always using devices 0..N
- Validates that `devices` is only passed with `TabPFNMode.LOCAL`
- Backward compatible — existing callers using `num_gpus` are unaffected

## Motivation
Distributed eval workloads need to pin different pipeline instances to specific GPUs. Previously the only control was `num_gpus`, which always selected devices starting from 0.

## Usage
```python
pipeline = TabPFNTSPipeline(
    tabpfn_mode=TabPFNMode.LOCAL,
    devices=[2, 3],
)
```

## Test plan
- [ ] Verify single-GPU fallback uses `self.devices[0]` instead of hardcoded 0
- [ ] Verify multi-GPU parallel path indexes into `self.devices`
- [ ] Verify `devices` with CLIENT mode raises `ValueError`
- [ ] Verify backward compat: `num_gpus=2` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)