### PR TITLE
Move autogluon.timeseries from a required dependency to an optional one, and add the lower bound as PR #98 suggests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
     "fev>=0.6.1",
 ]
 
+[project.optional-dependencies]
+benchmarking = [
+    "autogluon.timeseries>=1.5.0",
+]
+
 
 [tool.hatch.version]
 source = "vcs"
@@ -41,6 +46,7 @@ exclude = ["docs", "gift_eval"]
 
 [dependency-groups]
 dev = [
+    "tabpfn-time-series[benchmarking]",
     "pytest>=8.4.1",
     "jupyter",
     "wandb>=0.19.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "backoff>=2.2.1",
     "tabpfn-common-utils[telemetry-interactive]>=0.2.2",
     "fev>=0.6.1",
-    "autogluon.timeseries",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 benchmarking = [
-    "autogluon.timeseries>=1.5.0",
+    "autogluon.timeseries>=1.5.0, <2.0"
 ]
 
 


### PR DESCRIPTION
 ## Summary                                                                                                                                          
  - Move `autogluon.timeseries` from required to optional dependency (extra `[benchmarking]`)                                                         
  - Add lower bound `>=1.5.0` to fix pip resolution depth issue                                                                  
  - Fixes #96 (`pip install` fails with `resolution-too-deep` due to autogluon's large dependency tree)  
  - Closes https://github.com/PriorLabs/tabpfn-time-series/pull/98
  