### PR TITLE
ci: plumb TABPFN_TOKEN env var into pytest workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,5 +58,6 @@ jobs:
       - name: Run Tests
         env:
           TABPFN_CLIENT_API_KEY: ${{ secrets.TABPFN_CLIENT_API_KEY }}
+          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: uv run pytest tests


### PR DESCRIPTION
Unblocks `LOCAL`-mode tests after the v1.1.0 default-bump PR.

The v3 checkpoint requires license-token download (gated by `TABPFN_TOKEN`). The repo secret already exists; this PR adds the workflow env-var passthrough so `pytest` can actually see it.
