### PR TITLE
chore: add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PriorLabs/research
+* @PriorLabs/opensource-review-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @PriorLabs/research


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` so PRs (especially dependabot) get an automatic reviewer assignment instead of going unowned. Surfaced during the BearingPoint pre-submission self-scan when we noticed dependabot PRs weren't getting reviewed promptly.
- Single fallback team only; matches the pattern already used by sibling repos.

## Test plan
- [ ] CI green
- [ ] Open a test PR or wait for next dependabot PR; confirm the team is auto-assigned as reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)