### PR TITLE
chore: add THIRD-PARTY-NOTICES.md

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,50 @@
+# Third-Party Notices
+
+This file documents third-party code copied or adapted into this repository,
+with upstream attribution preserved. Transitive dependencies installed via
+`pip` are governed by their own licenses (see `pyproject.toml` for the
+canonical list).
+
+---
+
+## Summary
+
+| Upstream | Local path | Upstream license |
+|---|---|---|
+| AutoGluon — `TimeSeriesDataFrame` | `tabpfn_time_series/ts_dataframe.py` | Apache-2.0 |
+| Salesforce GIFT-Eval — `data.py` | `gift_eval/data.py` | Apache-2.0 |
+
+---
+
+## Per-upstream notices
+
+### AutoGluon — TimeSeriesDataFrame
+
+**Upstream:** https://github.com/autogluon/autogluon/blob/main/autogluon/timeseries/ts_dataframe.py
+**Local path:** `tabpfn_time_series/ts_dataframe.py`
+**License:** Apache-2.0
+**Modifications:** File copied verbatim; removed AutoGluon dependency and the
+local-file-loading features. Per-file header preserved at the top of the file.
+
+### Salesforce — GIFT-Eval data loading
+
+**Upstream:** https://github.com/SalesforceAIResearch/gift-eval
+**Local path:** `gift_eval/data.py`
+**License:** Apache-2.0
+**Copyright:** Copyright (c) 2023, Salesforce, Inc.
+**Modifications:** Per-file copyright and Apache-2.0 license header preserved
+verbatim at the top of the file.
+
+> Note: the rest of `gift_eval/` contains TabPFN integration code that targets
+> the Salesforce-published GIFT-EVAL benchmark but is not directly derived
+> from Salesforce source.
+
+---
+
+## Adding new entries
+
+When vendoring or adapting third-party code:
+
+1. Preserve the upstream copyright and license header verbatim at the top of the affected source file.
+2. If the upstream ships a `LICENSE` / `NOTICE` file, vendor that file alongside the code.
+3. Add a row to the summary table and a per-upstream notice to this file.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -20,13 +20,16 @@ canonical list).
 
 ### AutoGluon — TimeSeriesDataFrame
 
-**Upstream:** https://github.com/autogluon/autogluon/blob/main/autogluon/timeseries/ts_dataframe.py
+**Upstream:** https://github.com/autogluon/autogluon (path: `timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py`)
 **Local path:** `tabpfn_time_series/ts_dataframe.py`
 **License:** Apache-2.0
-**Modifications:** File copied verbatim; removed AutoGluon dependency and the
-local-file-loading features. Per-file header preserved at the top of the file.
+**Copyright:** Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. (per the AutoGluon `NOTICE` file)
+**Modifications:** Adapted from upstream; removed the AutoGluon dependency and the
+local-file-loading features. Upstream attribution preserved at the top of the file. Upstream
+does not ship a per-file copyright header, so attribution is carried in this NOTICE plus the
+in-file pointer to the upstream path.
 
-### Salesforce — GIFT-Eval data loading
+### Salesforce GIFT-Eval — `data.py`
 
 **Upstream:** https://github.com/SalesforceAIResearch/gift-eval
 **Local path:** `gift_eval/data.py`

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -48,6 +48,6 @@ verbatim at the top of the file.
 
 When vendoring or adapting third-party code:
 
-1. Preserve the upstream copyright and license header verbatim at the top of the affected source file.
-2. If the upstream ships a `LICENSE` / `NOTICE` file, vendor that file alongside the code.
-3. Add a row to the summary table and a per-upstream notice to this file.
+1. Preserve any upstream per-file copyright and license header verbatim. If the upstream does not ship a per-file header, add an attribution block citing the upstream URL, copyright holder, and SPDX license identifier (as in `tabpfn_time_series/ts_dataframe.py`).
+2. When vendoring a whole directory of upstream code, also vendor the upstream `LICENSE` / `NOTICE` file alongside it. For single-file adaptations, the in-file attribution plus the entry in this NOTICE file is sufficient.
+3. Add a row to the summary table and a per-upstream notice to this file, including the upstream copyright line when one is published.

--- a/tabpfn_time_series/ts_dataframe.py
+++ b/tabpfn_time_series/ts_dataframe.py
@@ -1,6 +1,11 @@
-# This file is copied from https://github.com/autogluon/autogluon/blob/main/autogluon/timeseries/ts_dataframe.py
-# and modified to remove the autogluon dependency.
-#   - remove the features that allow loading directly from a local file.
+# Adapted from AutoGluon: https://github.com/autogluon/autogluon
+#   path: timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: removed the AutoGluon dependency and the features that allow
+# loading directly from a local file.
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Add `THIRD-PARTY-NOTICES.md` documenting third-party code adapted or copied into this repository, with upstream attribution preserved.
- Upstream licenses verified via the GitHub API.

## Test plan
- [ ] CI green
- [ ] `THIRD-PARTY-NOTICES.md` shows on repo landing page