### PR TITLE
chore: document vendored Amazon Chronos to_gluonts_univariate helper

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -13,6 +13,7 @@ canonical list).
 |---|---|---|
 | AutoGluon — `TimeSeriesDataFrame` | `tabpfn_time_series/ts_dataframe.py` | Apache-2.0 |
 | Salesforce GIFT-Eval — `data.py` | `gift_eval/data.py` | Apache-2.0 |
+| Amazon Chronos — `to_gluonts_univariate` | `tabpfn_time_series/data_preparation.py` (function) | Apache-2.0 |
 
 ---
 
@@ -41,6 +42,14 @@ verbatim at the top of the file.
 > Note: the rest of `gift_eval/` contains TabPFN integration code that targets
 > the Salesforce-published GIFT-EVAL benchmark but is not directly derived
 > from Salesforce source.
+
+### Amazon Chronos — `to_gluonts_univariate`
+
+**Upstream:** https://github.com/amazon-science/chronos-forecasting (path: `scripts/evaluation/evaluate.py`, line 28 at the pinned commit)
+**Local path:** `tabpfn_time_series/data_preparation.py` (function `to_gluonts_univariate`)
+**License:** Apache-2.0
+**Copyright:** Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+**Modifications:** Adapted as a single-function vendoring from the upstream Chronos evaluation script. Upstream pins to a specific commit (`ad410c9`) referenced in the in-file attribution block.
 
 ---
 

--- a/tabpfn_time_series/data_preparation.py
+++ b/tabpfn_time_series/data_preparation.py
@@ -205,7 +205,11 @@ offset_alias_to_period_alias = {
 }
 
 
-# From https://github.com/amazon-science/chronos-forecasting/blob/ad410c9c0ae0d499aeec9a7af09b0636844b6274/scripts/evaluation/evaluate.py#L28
+# Adapted from amazon-science/chronos-forecasting:
+#   https://github.com/amazon-science/chronos-forecasting/blob/ad410c9c0ae0d499aeec9a7af09b0636844b6274/scripts/evaluation/evaluate.py#L28
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 def to_gluonts_univariate(hf_dataset: datasets.Dataset):
     series_fields = [
         col


### PR DESCRIPTION
## Summary
- `to_gluonts_univariate` in `tabpfn_time_series/data_preparation.py` was adapted from Amazon Chronos's evaluation script with only a URL pointer to the upstream commit and no attribution block.
- Adds the Apache-2.0 attribution (`Copyright Amazon.com, Inc. or its affiliates`) to the source file and a corresponding entry in `THIRD-PARTY-NOTICES.md`.

Surfaced during a broader third-party-code sweep, in the same spirit as #129.

## Test plan
- [ ] CI green
- [ ] `THIRD-PARTY-NOTICES.md` lists three entries now (AutoGluon + Salesforce + Chronos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)