### PR TITLE
docs: trim install line (CI sanity-check after #131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ On top of that, thanks to **[tabpfn-client](https://github.com/automl/tabpfn-cli
 
 ## ⚙️ Installation
 
-You can install the package via pip:
+Install via pip:
 
 ```bash
 pip install tabpfn-time-series


### PR DESCRIPTION
## Summary
Tiny README copy edit. Real purpose: act as a sanity-check PR after #131 (`pull_request_target` → `pull_request` switch) to confirm:

- [ ] CI fires on the new trigger
- [ ] Ruff lint job runs and passes
- [ ] Test matrix runs across all OS / Python combinations
- [ ] `secrets.TABPFN_CLIENT_API_KEY` / `secrets.TABPFN_TOKEN` / `secrets.HF_TOKEN` are present (since this is a same-repo branch, not a fork)
- [ ] No exfiltration path — fork PRs would see empty secret env vars

Merge once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)