### PR TITLE
fix: resolve default v3 TS ckpt into tabpfn cache dir

### DIFF
--- a/tabpfn_time_series/defaults.py
+++ b/tabpfn_time_series/defaults.py
@@ -26,7 +26,9 @@ def _default_ckpt_path() -> str:
 
 
 def resolve_default_ckpt(tabpfn_config: dict) -> dict:
-    """Set `model_path` to the v3 ts ckpt (resolved into tabpfn's cache dir)
-    when not provided. tabpfn handles the actual download on first call.
-    User-supplied paths pass through unchanged."""
-    return {"model_path": _default_ckpt_path(), **tabpfn_config}
+    """Default `model_path` to the v3 TS ckpt (in tabpfn's cache dir) when
+    absent or None; a user-supplied path passes through unchanged."""
+    config = {**tabpfn_config}
+    if config.get("model_path") is None:
+        config["model_path"] = _default_ckpt_path()
+    return config

--- a/tabpfn_time_series/defaults.py
+++ b/tabpfn_time_series/defaults.py
@@ -11,24 +11,15 @@ TABPFN_V3_TS_CHECKPOINT = "tabpfn-v3-regressor-v3_20260506_timeseries.ckpt"
 TABPFN_DEFAULT_CONFIG: dict = {}
 
 
-def _default_ckpt_path() -> str:
-    """Absolute path to the v3 TS ckpt inside tabpfn's model cache dir.
-
-    `tabpfn`'s `resolve_model_path` treats a non-None `model_path` as a literal
-    path: a bare filename resolves relative to the *cwd*, bypassing the cache
-    dir entirely (re-downloads per working directory). Routing the filename
-    through tabpfn's own cache resolver instead makes the ckpt download into
-    (and load from) the standard cache dir -- honoring `model_cache_dir` /
-    `XDG_CACHE_HOME`, shared with plain `tabpfn`, cwd-independent."""
-    from tabpfn.model_loading import prepend_cache_path
-
-    return prepend_cache_path(TABPFN_V3_TS_CHECKPOINT)
-
-
 def resolve_default_ckpt(tabpfn_config: dict) -> dict:
     """Default `model_path` to the v3 TS ckpt (in tabpfn's cache dir) when
     absent or None; a user-supplied path passes through unchanged."""
     config = {**tabpfn_config}
     if config.get("model_path") is None:
-        config["model_path"] = _default_ckpt_path()
+        # Route the bare filename through tabpfn's cache resolver: otherwise
+        # `resolve_model_path` treats it as a literal path relative to the cwd,
+        # bypassing the model cache dir (re-downloads per working directory).
+        from tabpfn.model_loading import prepend_cache_path
+
+        config["model_path"] = prepend_cache_path(TABPFN_V3_TS_CHECKPOINT)
     return config

--- a/tabpfn_time_series/defaults.py
+++ b/tabpfn_time_series/defaults.py
@@ -11,7 +11,22 @@ TABPFN_V3_TS_CHECKPOINT = "tabpfn-v3-regressor-v3_20260506_timeseries.ckpt"
 TABPFN_DEFAULT_CONFIG: dict = {}
 
 
+def _default_ckpt_path() -> str:
+    """Absolute path to the v3 TS ckpt inside tabpfn's model cache dir.
+
+    `tabpfn`'s `resolve_model_path` treats a non-None `model_path` as a literal
+    path: a bare filename resolves relative to the *cwd*, bypassing the cache
+    dir entirely (re-downloads per working directory). Routing the filename
+    through tabpfn's own cache resolver instead makes the ckpt download into
+    (and load from) the standard cache dir -- honoring `model_cache_dir` /
+    `XDG_CACHE_HOME`, shared with plain `tabpfn`, cwd-independent."""
+    from tabpfn.model_loading import prepend_cache_path
+
+    return prepend_cache_path(TABPFN_V3_TS_CHECKPOINT)
+
+
 def resolve_default_ckpt(tabpfn_config: dict) -> dict:
-    """Set `model_path` to the v3 ts ckpt when not provided. tabpfn handles the
-    actual download on first call. User-supplied paths pass through unchanged."""
-    return {"model_path": TABPFN_V3_TS_CHECKPOINT, **tabpfn_config}
+    """Set `model_path` to the v3 ts ckpt (resolved into tabpfn's cache dir)
+    when not provided. tabpfn handles the actual download on first call.
+    User-supplied paths pass through unchanged."""
+    return {"model_path": _default_ckpt_path(), **tabpfn_config}


### PR DESCRIPTION
## Problem

In `LOCAL` mode, `resolve_default_ckpt()` set `model_path` to the bare filename
`tabpfn-v3-regressor-v3_20260506_timeseries.ckpt`.

`tabpfn`'s `resolve_model_path` only routes through the model cache dir when
`model_path is None`; a non-`None` value is treated as a literal path. A bare
filename therefore resolves relative to the **current working directory**
(`Path(name).parent == "."`). Consequences:

- The 223 MB v3 TS checkpoint is (re-)downloaded into whatever directory the
  process happens to run from.
- The standard tabpfn cache (`get_cache_dir()`) is bypassed entirely.
- `model_cache_dir` / `XDG_CACHE_HOME` have no effect.
- Not shared with plain `tabpfn` usage; re-downloads when cwd changes.

## Fix

Add `_default_ckpt_path()` which routes the filename through tabpfn's own
`prepend_cache_path()` → an absolute path inside `get_cache_dir()`. The ckpt is
downloaded once, reused from any cwd, shared with plain tabpfn, and respects
the cache-dir settings. A user-supplied `model_path` still passes through
unchanged (`{..., **tabpfn_config}`).

`CLIENT` mode is unaffected (it never calls `resolve_default_ckpt`).

## Verification

- `resolve_default_ckpt({})['model_path']` →
  `<cache_dir>/tabpfn-v3-regressor-v3_20260506_timeseries.ckpt`
- `resolve_default_ckpt({'model_path': '/x.ckpt'})` → `/x.ckpt` (override preserved)
- LOCAL pipeline run from a different cwd: loads from cache, no re-download,
  no stray ckpt written to cwd.
- Existing guard test `test_default_pipeline_config_uses_v3_defaults` still
  passes (constant / `max_context_length` / `max_top_k` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
