### PR TITLE
fix: correct stale repo metadata (Colab badge, project URLs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Zero-Shot Time Series Forecasting with TabPFN
 
 [![PyPI version](https://badge.fury.io/py/tabpfn-time-series.svg)](https://badge.fury.io/py/tabpfn-time-series)
-[![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PriorLabs/tabpfn-time-series/blob/main/quickstart.ipynb)
+[![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PriorLabs/tabpfn-time-series/blob/main/examples/quickstart.ipynb)
 [![Discord](https://img.shields.io/discord/1285598202732482621?color=7289da&label=Discord&logo=discord&logoColor=ffffff)](https://discord.com/channels/1285598202732482621/)
 [![arXiv](https://img.shields.io/badge/arXiv-2501.02945-<COLOR>.svg)](https://arxiv.org/abs/2501.02945v3)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ dev = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/liam-sbhoo/tabpfn-time-series"
-"Bug Tracker" = "https://github.com/liam-sbhoo/tabpfn-time-series/issues"
+"Homepage" = "https://github.com/PriorLabs/tabpfn-time-series"
+"Bug Tracker" = "https://github.com/PriorLabs/tabpfn-time-series/issues"
 
 [tool.pytest.ini_options]
 markers = ["uses_tabpfn_client: These tests require a TabPFN API key."]


### PR DESCRIPTION
Two small, independent repo-metadata fixes.

### 1. README — broken Colab badge
The badge linked to `…/blob/main/quickstart.ipynb`, but the notebook is at
`examples/quickstart.ipynb` → the Colab link 404s. Fixed the path.

### 2. pyproject — stale project URLs
`[project.urls]` Homepage / Bug Tracker still pointed at
`github.com/liam-sbhoo/tabpfn-time-series`; the repo is now under
`PriorLabs/`. Updated both (these surface on the PyPI project page).

---

_Note: this branch originally also carried a fix for the pandas empty/all-NA
`pd.concat` `FutureWarning` in `feature_transformer.py`. That has been removed
from this PR and will be handled separately. This PR is now metadata-only._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
