### PR TITLE
Changed the default of the Pipeline object to Local

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,7 @@ dev = [
 "Bug Tracker" = "https://github.com/PriorLabs/tabpfn-time-series/issues"
 
 [tool.pytest.ini_options]
-markers = ["uses_tabpfn_client: These tests require a TabPFN API key."]
+markers = [
+    "uses_tabpfn_client: These tests require a TabPFN API key.",
+    "uses_tabpfn_local: These tests require a local TabPFN model.",
+]

--- a/tabpfn_time_series/pipeline.py
+++ b/tabpfn_time_series/pipeline.py
@@ -213,7 +213,7 @@ class TabPFNTSPipeline:
         self,
         max_context_length: int = 32768,
         temporal_features: list[FeatureGenerator] = TABPFN_TS_DEFAULT_FEATURES,
-        tabpfn_mode: TabPFNMode = TabPFNMode.CLIENT,
+        tabpfn_mode: TabPFNMode = TabPFNMode.LOCAL,
         tabpfn_output_selection: Literal["mean", "median", "mode"] = "median",
         tabpfn_model_config: dict = TABPFN_DEFAULT_CONFIG,
     ):
@@ -232,7 +232,7 @@ class TabPFNTSPipeline:
             tabpfn_mode: Inference mode for TabPFN.
                 - TabPFNMode.CLIENT: Use the cloud API (recommended, no GPU needed)
                 - TabPFNMode.LOCAL: Run locally on your machine (requires GPU for speed)
-                Default: TabPFNMode.CLIENT.
+                Default: TabPFNMode.LOCAL.
             tabpfn_output_selection: Method to aggregate TabPFN ensemble predictions.
                 Options: "mean", "median", "mode". Default: "median".
             tabpfn_model_config: Configuration dictionary for the TabPFN model.

--- a/tabpfn_time_series/predictor.py
+++ b/tabpfn_time_series/predictor.py
@@ -30,6 +30,23 @@ class TabPFNMode(str, Enum):
     CLIENT = "client"
 
 
+def _select_local_worker_class() -> Type[ParallelWorker]:
+    """Pick the worker for local TabPFN from the available torch device.
+
+    CUDA uses the multi-GPU worker. MPS and CPU both use the CPU worker for
+    item-level parallelism; tabpfn routes the tensor compute to MPS itself via
+    device="auto". A bare CPU is flagged as slow for long contexts.
+    """
+    if torch.cuda.is_available():
+        return GPUParallelWorker
+    if not torch.backends.mps.is_available():
+        logger.warning(
+            "Running TabPFN locally on CPU; inference will be slow for long contexts. "
+            "Use a CUDA GPU, or TabPFNMode.CLIENT for cloud inference."
+        )
+    return CPUParallelWorker
+
+
 @set_extension("time-series")
 class TimeSeriesPredictor:
     def __init__(
@@ -38,9 +55,7 @@ class TimeSeriesPredictor:
         worker_class: Type[ParallelWorker] = None,
         worker_kwargs: dict = {},
     ):
-        worker_class = worker_class or (
-            GPUParallelWorker if torch.cuda.is_available() else CPUParallelWorker
-        )
+        worker_class = worker_class or _select_local_worker_class()
         self._worker = worker_class(
             inference_routine=model_adapter.predict,
             **worker_kwargs,
@@ -62,17 +77,14 @@ class TimeSeriesPredictor:
             tabpfn_output_selection=tabpfn_output_selection,
         )
 
-        worker_class = None
         if tabpfn_class == TabPFNClientRegressor:
             from tabpfn_time_series.worker.parallel_workers import (
                 TabPFNClientCPUParallelWorker,
             )
 
             worker_class = TabPFNClientCPUParallelWorker
-        elif tabpfn_class == TabPFNRegressor and torch.cuda.is_available():
-            worker_class = GPUParallelWorker
-        elif tabpfn_class == TabPFNRegressor and not torch.cuda.is_available():
-            worker_class = CPUParallelWorker
+        elif tabpfn_class == TabPFNRegressor:
+            worker_class = _select_local_worker_class()
         else:
             raise ValueError(f"Expected TabPFN-family regressor, got {tabpfn_class}")
 

--- a/tabpfn_time_series/predictor.py
+++ b/tabpfn_time_series/predictor.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Type, Dict, Any
 
 import torch
+import warnings
 from sklearn.base import RegressorMixin
 
 from tabpfn_time_series.ts_dataframe import TimeSeriesDataFrame
@@ -41,7 +42,6 @@ def _select_local_worker_class() -> Type[ParallelWorker]:
         return GPUParallelWorker
     has_mps = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
     if not has_mps:
-        import warnings
         warnings.warn(
             "Running TabPFN locally on CPU; inference will be slow for long contexts. "
             "Use a CUDA GPU, or TabPFNMode.CLIENT for cloud inference.",

--- a/tabpfn_time_series/predictor.py
+++ b/tabpfn_time_series/predictor.py
@@ -39,10 +39,14 @@ def _select_local_worker_class() -> Type[ParallelWorker]:
     """
     if torch.cuda.is_available():
         return GPUParallelWorker
-    if not torch.backends.mps.is_available():
-        logger.warning(
+    has_mps = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    if not has_mps:
+        import warnings
+        warnings.warn(
             "Running TabPFN locally on CPU; inference will be slow for long contexts. "
-            "Use a CUDA GPU, or TabPFNMode.CLIENT for cloud inference."
+            "Use a CUDA GPU, or TabPFNMode.CLIENT for cloud inference.",
+            UserWarning,
+            stacklevel=2,
         )
     return CPUParallelWorker
 

--- a/tests/test_freq_alias.py
+++ b/tests/test_freq_alias.py
@@ -7,6 +7,7 @@ across pandas versions.
 
 from unittest.mock import MagicMock
 
+import pytest
 from pandas.tseries.frequencies import to_offset
 from gluonts.time_feature import norm_freq_str
 from gift_eval.data import (
@@ -40,6 +41,9 @@ def test_legacy_aliases_unchanged_simple():
         assert NEW_PANDAS_TS_ALIASES.get(alias, alias) == alias
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*is deprecated and will be removed in a future version.*:FutureWarning"
+)
 def test_prediction_length_minimal():
     def make_ds(freq: str, name: str = "regular", term: Term = Term.SHORT) -> Dataset:
         mock_ds = MagicMock(spec=Dataset)


### PR DESCRIPTION
The default of the TS Pipeline object is currently CLIENT. We want to switch this to local. This is in preparation for the explainability PR. In the process, I also added a warning for CPU usage and simplified worker selection.