### PR TITLE
CODEOWNERS: scope to sensitive paths only (mirror TabPFN)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,19 @@
-* @PriorLabs/opensource-review-team
+# Code ownership for tabpfn-time-series.
+#
+# Only security / supply-chain sensitive paths are owned. General code (the
+# library, tests, docs) intentionally has NO code owner and only needs a normal
+# approving review, mirroring PriorLabs/TabPFN. This lets any maintainer review
+# ordinary changes while keeping publish/CI/governance files gated behind
+# release maintainers.
+
+# Publish & release workflows — direct PyPI / TestPyPI supply-chain surface
+.github/workflows/publish-release.yml    @PriorLabs/release-maintainers
+.github/workflows/publish-test.yml       @PriorLabs/release-maintainers
+
+# CI workflow — runs with TABPFN_TOKEN in the environment; a malicious edit
+# could exfiltrate the secret, so require release-maintainer review.
+.github/workflows/pull_request.yml       @PriorLabs/release-maintainers
+
+# Governance files — prevent silently weakening ownership or security policy.
+.github/CODEOWNERS                       @PriorLabs/release-maintainers
+SECURITY.md                              @PriorLabs/release-maintainers


### PR DESCRIPTION
## What & why

Today `.github/CODEOWNERS` is a single blanket line:
```
* @PriorLabs/opensource-review-team
```
so **every** PR requires a code-owner review from that team. This diverges from **PriorLabs/TabPFN**, which owns only security/supply-chain sensitive paths and leaves general code to a normal approving review.

This PR mirrors the TabPFN model: scope ownership to sensitive paths only, via `@PriorLabs/release-maintainers`.

## After this change

- **Owned (require release-maintainer review):** `publish-release.yml`, `publish-test.yml`, `pull_request.yml` (holds `TABPFN_TOKEN`), `.github/CODEOWNERS`, `SECURITY.md`.
- **Unowned (normal approval from any maintainer):** everything else — the library, tests, docs.

Branch protection is unchanged (`require_code_owner_reviews` stays `true`); general code just no longer has an owner, so it's satisfied by a normal review — same as TabPFN.

## Note
Because `CODEOWNERS` is itself an owned path, this PR still needs a release-maintainer approval (or admin merge) to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
