### PR TITLE
CI: let fork PRs run the test suite without secrets (+ unbreak the client tests)

### DIFF
--- a/.github/workflows/cache-models.yml
+++ b/.github/workflows/cache-models.yml
@@ -1,0 +1,72 @@
+name: Cache TabPFN models
+
+# Populates a GitHub Actions cache with the TabPFN checkpoints the LOCAL-mode
+# tests need.
+#
+# Downloading a checkpoint requires license acceptance (`TABPFN_TOKEN`), and
+# GitHub never exposes secrets to workflows triggered by fork PRs. Caches
+# written on the default branch, however, *are* readable by every PR — forks
+# included. So `main` downloads the weights once and PR jobs restore them (see
+# `pull_request.yml`), which lets external contributors run the full test suite
+# without any credentials.
+#
+# The weekly schedule exists because GitHub evicts caches that go unread for 7
+# days; it keeps the entry warm during quiet periods.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/download_test_models.py"
+      - "tabpfn_time_series/defaults.py"
+      - ".github/workflows/cache-models.yml"
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cache_models:
+    name: Download and cache model checkpoints
+    runs-on: ubuntu-latest
+    env:
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Restore model cache
+        id: restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: tabpfn-models-v1-${{ hashFiles('scripts/download_test_models.py', 'tabpfn_time_series/defaults.py') }}
+          enableCrossOsArchive: true
+
+      - name: Download checkpoints
+        if: steps.restore.outputs.cache-hit != 'true'
+        env:
+          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: uv run python scripts/download_test_models.py
+
+      - name: Save model cache
+        if: steps.restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: tabpfn-models-v1-${{ hashFiles('scripts/download_test_models.py', 'tabpfn_time_series/defaults.py') }}
+          enableCrossOsArchive: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,13 @@ name: In pull request
 #   - Secrets ARE exposed to PRs from branches in this repo, so internal
 #     contributors still get full test coverage.
 # Tests that need TABPFN_CLIENT_API_KEY / TABPFN_TOKEN / HF_TOKEN should
-# detect missing-env-var and skip on fork PRs.
+# detect missing-env-var and skip on fork PRs (`tests/conftest.py` does this
+# for the `uses_tabpfn_client` / `uses_tabpfn_local` markers).
+#
+# LOCAL-mode tests don't have to skip on forks: `cache-models.yml` downloads the
+# checkpoints on `main` into a cache that PRs from forks can read, so the model
+# is already on disk and `tabpfn` never needs a token to fetch it. They only
+# skip when that cache is cold.
 
 on:
   pull_request:
@@ -51,6 +57,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
+    env:
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
     steps:
       - uses: actions/checkout@v4
 
@@ -65,12 +73,25 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      # Read-only: the cache is written on `main` by `cache-models.yml`. A miss
+      # is not fatal — internal PRs re-download with TABPFN_TOKEN, fork PRs skip
+      # the LOCAL-mode tests.
+      - name: Restore TabPFN model cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: tabpfn-models-v1-${{ hashFiles('scripts/download_test_models.py', 'tabpfn_time_series/defaults.py') }}
+          restore-keys: |
+            tabpfn-models-v1-
+          enableCrossOsArchive: true
+
       - name: Run Tests
         # Secrets are only available to PRs from branches in this repo, not
-        # from forks. Tests that require these should skip gracefully when
-        # the env var is empty (i.e. on fork PRs).
+        # from forks; they resolve to the empty string there. `tests/conftest.py`
+        # turns that into skips instead of failures. `-ra` so the skip reasons
+        # are visible in the job log.
         env:
           TABPFN_CLIENT_API_KEY: ${{ secrets.TABPFN_CLIENT_API_KEY }}
           TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: uv run pytest tests
+        run: uv run pytest tests -ra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "tqdm",
     "pandas>=2.1.2",
     "gluonts>=0.16.0",
-    "tabpfn-client>=0.2.8",
+    # 0.3.0 is the oldest client the cloud API still accepts: older ones get a
+    # 426 Upgrade Required from `try_connection` before any prediction runs.
+    "tabpfn-client>=0.3.0",
     "tabpfn>=8.0.0",
     "statsmodels>=0.14.5",
     "datasets>=2.15",

--- a/scripts/download_test_models.py
+++ b/scripts/download_test_models.py
@@ -1,0 +1,89 @@
+"""Download the TabPFN checkpoints the test suite needs for LOCAL-mode inference.
+
+Downloading a checkpoint requires a one-time license acceptance, which in CI
+means a `TABPFN_TOKEN`. Fork PRs never get repository secrets, so this script is
+run on `main` (see `.github/workflows/cache-models.yml`) and the resulting
+directory is stored in the GitHub Actions cache; PR jobs restore that cache and
+find the checkpoints already on disk, where `tabpfn` loads them without
+contacting Hugging Face at all.
+
+Set `TABPFN_MODEL_CACHE_DIR` (or pass `--cache-dir`) to control where the
+checkpoints land; both this script and `tabpfn` itself honour it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from tabpfn.model_loading import (
+    download_model,
+    get_cache_dir,
+    resolve_model_version,
+)
+
+from tabpfn_time_series.defaults import TABPFN_V3_TS_CHECKPOINT
+
+logger = logging.getLogger(__name__)
+
+# Checkpoints exercised by the LOCAL-mode tests. Currently only the TS ckpt that
+# `resolve_default_ckpt` picks; keep this in sync with `defaults.py`.
+REQUIRED_CHECKPOINTS = [TABPFN_V3_TS_CHECKPOINT]
+
+# A truncated or error-page "checkpoint" would be worse than no cache at all:
+# the tests would fail on a corrupt file instead of skipping. Real ckpts are
+# hundreds of MB, so anything this small means the download went wrong.
+MIN_CHECKPOINT_BYTES = 10 * 1024 * 1024
+
+
+def download_checkpoints(cache_dir: Path) -> None:
+    """Download every required checkpoint that is not already in `cache_dir`."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    for ckpt_name in REQUIRED_CHECKPOINTS:
+        path = cache_dir / ckpt_name
+        if path.exists():
+            logger.info("Already cached, skipping: %s", path)
+            continue
+
+        logger.info("Downloading %s -> %s", ckpt_name, path)
+        result = download_model(
+            to=path,
+            version=resolve_model_version(str(path)),
+            which="regressor",
+            model_name=ckpt_name,
+        )
+        if result != "ok":
+            raise RuntimeError(f"Failed to download {ckpt_name}: {result}")
+
+        size = path.stat().st_size if path.exists() else 0
+        if size < MIN_CHECKPOINT_BYTES:
+            raise RuntimeError(
+                f"{ckpt_name} downloaded but is only {size} bytes; refusing to "
+                "cache what looks like a failed download"
+            )
+        logger.info("Downloaded %s (%.0f MB)", ckpt_name, size / 1024**2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Where to store the checkpoints (default: tabpfn's cache dir).",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    cache_dir = args.cache_dir or get_cache_dir()
+    download_checkpoints(cache_dir)
+    logger.info("All required checkpoints are in %s", cache_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Skip integration tests whose credentials / model weights aren't available.
+
+Two markers gate the integration tests (declared in `pyproject.toml`):
+
+* `uses_tabpfn_client` needs `TABPFN_CLIENT_API_KEY` — a cloud call, so there is
+  no offline substitute.
+* `uses_tabpfn_local` needs the TabPFN checkpoint on disk. That is satisfied
+  either by a checkpoint already in the model cache (CI restores one that `main`
+  populated — see `.github/workflows/cache-models.yml`) or by a `TABPFN_TOKEN`
+  to download it on the fly.
+
+Fork PRs get neither secret, so without this hook the whole integration suite
+fails there with `TabPFNLicenseError` / missing-key assertions on changes that
+have nothing to do with TabPFN. Skipping keeps the signal honest for external
+contributors while internal PRs — which do get the secrets — still run
+everything.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _skip_reason_for_client() -> str | None:
+    if os.getenv("TABPFN_CLIENT_API_KEY"):
+        return None
+    return "TABPFN_CLIENT_API_KEY is not set (expected on fork PRs)"
+
+
+@functools.lru_cache(maxsize=1)
+def _skip_reason_for_local() -> str | None:
+    from tabpfn.model_loading import prepend_cache_path
+
+    from tabpfn_time_series.defaults import TABPFN_V3_TS_CHECKPOINT
+
+    checkpoint = Path(prepend_cache_path(TABPFN_V3_TS_CHECKPOINT))
+    if checkpoint.exists():
+        return None
+    if os.getenv("TABPFN_TOKEN"):
+        return None
+    return (
+        f"{checkpoint.name} is not in the model cache ({checkpoint.parent}) and "
+        "TABPFN_TOKEN is not set to download it (expected on fork PRs)"
+    )
+
+
+_SKIP_REASON_BY_MARKER = {
+    "uses_tabpfn_client": _skip_reason_for_client,
+    "uses_tabpfn_local": _skip_reason_for_local,
+}
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        for marker, skip_reason in _SKIP_REASON_BY_MARKER.items():
+            if item.get_closest_marker(marker) is None:
+                continue
+            reason = skip_reason()
+            if reason is not None:
+                item.add_marker(pytest.mark.skip(reason=reason))
+                break

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -259,6 +259,7 @@ def test_window_collapse_warns(explainer_factory):
         )
 
 
+@pytest.mark.uses_tabpfn_local
 def test_integration_local_tabpfn():
     """End-to-end against a local TabPFN model on a tiny series."""
     df = make_series(n=180)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -80,6 +80,7 @@ def create_toy_fev_task() -> fev.Task:
 
 
 class TestTabPFNTSPipeline:
+    @pytest.mark.uses_tabpfn_local
     def test_predict_local_mode(self):
         """Test predict method with local TabPFN mode."""
         context_tsdf = create_context_tsdf()
@@ -107,6 +108,7 @@ class TestTabPFNTSPipeline:
         assert len(result) == 6
         assert "target" in result.columns
 
+    @pytest.mark.uses_tabpfn_local
     def test_predict_df_with_prediction_length(self):
         """Test predict_df using prediction_length parameter."""
         context_df = create_context_df()
@@ -117,6 +119,7 @@ class TestTabPFNTSPipeline:
         assert result is not None
         assert len(result) == 6  # 2 items * 3 prediction steps
 
+    @pytest.mark.uses_tabpfn_local
     def test_predict_df_with_future_df(self):
         """Test predict_df using explicit future_df."""
         context_df = create_context_df()
@@ -134,6 +137,7 @@ class TestTabPFNTSPipeline:
         assert result is not None
         assert len(result) == 6
 
+    @pytest.mark.uses_tabpfn_local
     def test_predict_df_single_series(self):
         """Test predict_df with a single time series (no item_id column)."""
         dates = pd.date_range(start="2023-01-01", periods=10, freq="D")
@@ -171,6 +175,7 @@ class TestTabPFNTSPipeline:
         with pytest.raises(ValueError, match="exactly one"):
             pipeline.predict_df(context_df)
 
+    @pytest.mark.uses_tabpfn_local
     def test_custom_quantiles(self):
         """Test that custom quantiles are returned in the result."""
         context_tsdf = create_context_tsdf()
@@ -183,6 +188,7 @@ class TestTabPFNTSPipeline:
         for q in custom_quantiles:
             assert q in result.columns, f"Quantile {q} not in result columns"
 
+    @pytest.mark.uses_tabpfn_local
     def test_predict_fev(self):
         """Test predict_fev method with a real fev task."""
         task = create_toy_fev_task()

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -85,6 +85,7 @@ class TestTabPFNTimeSeriesPredictor:
 
         assert result is not None
 
+    @pytest.mark.uses_tabpfn_local
     def test_local_mode(self):
         """Test that predict method calls the worker's predict method"""
         train_tsdf, test_tsdf = create_test_data()

--- a/uv.lock
+++ b/uv.lock
@@ -1712,6 +1712,41 @@ wheels = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/a5accde175dee985311d949cfcb1249dcbb290f5ec83c994ea733311948f/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288", size = 30870, upload-time = "2025-12-16T00:29:17.669Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/63/bec827e70b7a0d4094e7476f863c0dbd6b5f0f1f91d9c9b32b76dcdfeb4e/google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d", size = 33214, upload-time = "2025-12-16T00:40:19.618Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/11b70614df04c289128d782efc084b9035ef8466b3d0a8757c1b6f5cf7ac/google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092", size = 33589, upload-time = "2025-12-16T00:40:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/00/a08a4bc24f1261cc5b0f47312d8aebfbe4b53c2e6307f1b595605eed246b/google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733", size = 34437, upload-time = "2025-12-16T00:35:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
 name = "graphviz"
 version = "0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -1845,19 +1880,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
 name = "hatch"
 version = "1.16.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1948,15 +1970,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
-]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1984,11 +1997,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
-[package.optional-dependencies]
-http2 = [
-    { name = "h2" },
-]
-
 [[package]]
 name = "huggingface-hub"
 version = "0.36.2"
@@ -2006,15 +2014,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
-]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -5816,29 +5815,33 @@ wheels = [
 
 [[package]]
 name = "tabpfn-client"
-version = "0.2.8"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "google-crc32c" },
+    { name = "httpx" },
     { name = "omegaconf" },
     { name = "pandas" },
     { name = "password-strength" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
     { name = "rich" },
     { name = "scikit-learn" },
     { name = "sseclient-py" },
+    { name = "tabpfn-common-utils" },
     { name = "tqdm" },
     { name = "typing-extensions" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c5/091234d4bb282c19caf52d23100a2cd91cb6b4399a07fe1986e0dff7b11c/tabpfn_client-0.2.8.tar.gz", hash = "sha256:adcf4374f75b0a7a391a4bfa03cad96d46203686187a8cdc769f4c4fe2414706", size = 1888144, upload-time = "2025-11-06T11:51:35.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/df/85af86742ebebfe45f756647ee6effc4ce4decf5f02929b3cf94c67d0c2c/tabpfn_client-0.3.3.tar.gz", hash = "sha256:0d221d8fd0f85b17dc44ee26f4837565ebc7932e5c0a27dec3fd163813491ba7", size = 187508, upload-time = "2026-07-08T13:12:56.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/7c/8e37e8e15b294cbe41faaab3665c38d40d282f5846d8074514587cc96482/tabpfn_client-0.2.8-py3-none-any.whl", hash = "sha256:27aedf3075258f677983318132e4494b939412dd8ff45e2aef7219b144000026", size = 1904648, upload-time = "2025-11-06T11:51:34.257Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/08/4dc6331be5aa1e9a1e2088265c37cbd195ecfb6ee81c14d4b632676413f3/tabpfn_client-0.3.3-py3-none-any.whl", hash = "sha256:c57c56ef7484078add2cbd3ffe0c240bc04f6515144e8fcbe223a72d03fa8ff9", size = 56275, upload-time = "2026-07-08T13:12:54.775Z" },
 ]
 
 [[package]]
 name = "tabpfn-common-utils"
-version = "0.2.21"
+version = "0.2.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -5848,12 +5851,13 @@ dependencies = [
     { name = "platformdirs" },
     { name = "posthog" },
     { name = "requests" },
+    { name = "ruff" },
     { name = "scikit-learn" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6d/3035d1d809e1243c1785ef218a21d87ce6c5a5750dcbb09d32e15e2c981f/tabpfn_common_utils-0.2.21.tar.gz", hash = "sha256:dc4f00c8a5e759fa91210eb19adfebe201ec49edc354075fe6e65031b0f76053", size = 1982106, upload-time = "2026-04-28T07:31:44.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/62/ec181b52e12f64eac179f31d0891ccb2b3f48552de32d8992e0f5144c808/tabpfn_common_utils-0.2.19.tar.gz", hash = "sha256:d5bb515f9c7bdda555d833542ab4c41a2cc7007e3ae57b9c302ad4f4f8186558", size = 1932394, upload-time = "2026-03-27T13:31:27.285Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/55/97fb9d02a5d4e28abd9e76b90b9ab2366df828588024d713ebb37750aead/tabpfn_common_utils-0.2.21-py3-none-any.whl", hash = "sha256:480b2f24a6150bc10a49485ca5e88885ffa476499ddc3d0c5f8080b379955cb9", size = 39799, upload-time = "2026-04-28T07:31:43.099Z" },
+    { url = "https://files.pythonhosted.org/packages/34/dd/4b6095777970f3f9e50144b5cfd993ad2e70a9c08fed3425d8c9e8f88784/tabpfn_common_utils-0.2.19-py3-none-any.whl", hash = "sha256:1f53f3f96ddccc99b27f80075437e7a3dd29666b6c2575ad03dc3f9ae6df9c38", size = 37295, upload-time = "2026-03-27T13:31:25.917Z" },
 ]
 
 [[package]]
@@ -5914,7 +5918,7 @@ requires-dist = [
     { name = "shapiq", marker = "extra == 'explainability'", specifier = ">=1.4" },
     { name = "statsmodels", specifier = ">=0.14.5" },
     { name = "tabpfn", specifier = ">=8.0.0" },
-    { name = "tabpfn-client", specifier = ">=0.2.8" },
+    { name = "tabpfn-client", specifier = ">=0.3.0" },
     { name = "tabpfn-common-utils", extras = ["telemetry-interactive"], specifier = ">=0.2.2" },
     { name = "tqdm" },
 ]


### PR DESCRIPTION
## Problem

Every PR from an external contributor fails the same 7 integration tests, regardless of what they changed. GitHub does not expose repository secrets to workflows triggered from a fork, so in those runs:

- **LOCAL-mode tests** raise `TabPFNLicenseError` — no `TABPFN_TOKEN`, so `tabpfn` can't accept the license and download the checkpoint.
- **CLIENT-mode tests** trip the `assert access_token is not None, "TABPFN_CLIENT_API_KEY is not set"` in `maybe_setup_tabpfn_client_on_github_actions()`.

`pull_request.yml` already says credential-dependent tests "should skip gracefully", and `pyproject.toml` already declares `uses_tabpfn_client` / `uses_tabpfn_local` — but nothing ever implemented the skip, and several LOCAL-mode tests were never marked. The result is a red X the contributor can't do anything about, which is what happened in #146: the fix there is a three-line bug fix, and the contributor had to hand-patch our CI to get a green run.

The other repos already solved this. This PR ports the approach tabpfn-extensions used in [875aa60](https://github.com/PriorLabs/tabpfn-extensions/commit/875aa60940d2ed1cfed8b32db80435fa5e422ddb) (h/t @Oscar) and adds the skip layer underneath it.

## Commit 1 — fork CI

**Cache the model weights on `main` (`.github/workflows/cache-models.yml`)**

Caches written on the default branch are readable by *every* PR, forks included — that's the loophole. `main` downloads the checkpoints the LOCAL-mode tests need (`scripts/download_test_models.py`, using `TABPFN_TOKEN`) into the Actions cache; `pull_request.yml` restores it read-only into `TABPFN_MODEL_CACHE_DIR` before the test step. `tabpfn` only hits Hugging Face when the checkpoint is missing from disk, so with a warm cache fork PRs run the LOCAL-mode tests for real — no token, no skip.

Triggers: push to `main` touching the script/`defaults.py`/the workflow, plus `workflow_dispatch`, plus a weekly cron (GitHub evicts caches unread for 7 days).

**Skip gracefully when that isn't possible (`tests/conftest.py`)**

- `uses_tabpfn_local` → skips only when the checkpoint is neither cached nor downloadable (cold cache *and* no `TABPFN_TOKEN`). Availability, not "is this CI", is the condition, so a fresh local clone without a token also gets skips rather than 13 confusing license errors.
- `uses_tabpfn_client` → skips when there's no `TABPFN_CLIENT_API_KEY`. A cloud call has no offline substitute, so these will always skip on forks; that's the floor, and it's the honest signal.

The download script refuses to cache a checkpoint under 10 MB, so a failed/truncated download can't poison the cache into a state where PRs *fail* instead of skip.

**Mark the LOCAL-mode tests that were missing `uses_tabpfn_local`** — taken from @Hrafz's work in #146 (credited as co-author).

Internal PRs are unaffected: they still get all three secrets, a cache miss just re-downloads as before, and nothing skips.

## Commit 2 — the client tests are broken on `main` today

I originally wrote this PR up saying @Hrafz's `tabpfn-client` version report was probably stale, since internal CI was green on 0.2.8 as of #144. **The first CI run on this branch disproved that**: 58 passed, 4 failed, and all four failures are the CLIENT-mode tests, which do run here because this branch has the secrets.

The traceback bottoms out in `tabpfn_client/client.py::_validate_response(..., only_version_check=True)` from `try_connection` — HTTP **426 Upgrade Required**. The cloud API no longer accepts 0.2.x clients, and it rejects them at connection time, before any prediction. The 426 branch raises `RuntimeError(load.get("detail"))` against a payload that no longer carries `detail`, which is why the failure reads as a bare `RuntimeError: None` and says nothing useful.

So: floor raised to `tabpfn-client>=0.3.0`, lock moved 0.2.8 → 0.3.3. This is not a CI-only problem — any user on 0.2.x is equally cut off. It rode along here because it was blocking this PR, and splitting it out is easy if you'd rather review it separately.

One side effect worth a look: 0.3.3 caps `tabpfn-common-utils<=0.2.19`, so the lock moves that 0.2.21 → 0.2.19. Our own floor is `>=0.2.2` so it resolves, but the downgrade is the client's constraint, not a choice here.

## Verification

Simulated a fork PR locally (empty `TABPFN_MODEL_CACHE_DIR`, no tokens): **44 passed, 18 skipped in ~9s**, against 7 failures on `main` today. Each skip prints why:

```
SKIPPED [1] tests/test_pipeline.py:83: tabpfn-v3-regressor-v3_20260506_timeseries.ckpt is not in
the model cache (...) and TABPFN_TOKEN is not set to download it (expected on fork PRs)
```

With a checkpoint present in the cache dir the LOCAL-mode tests are collected and run instead of skipped — confirmed with a stand-in file (it runs, then fails on the bogus weights, which is the point). The first CI run also confirms the restore step is non-fatal on a cold cache, and that LOCAL-mode tests still pass on an internal PR by downloading as before.

`ruff check` / `ruff format --check` clean. Two things I could **not** verify locally:

- The Hugging Face download itself — I have no `TABPFN_TOKEN`, so `cache-models.yml` runs for the first time when this merges. Worth triggering it via `workflow_dispatch` and watching. If the cache never populates, the fallback is the skip behaviour, i.e. today's fork experience minus the red X.
- The cloud calls on 0.3.3 — no API key locally. The client API surface we use (`init`, `set_access_token`, `TabPFNRegressor`) is unchanged, and CI on this branch has the key, so the run on this push is the real check.

## Follow-ups (not in this PR)

- #146 can drop its `Skip credential-dependent tests in fork CI` commit once this lands and rebase onto it; what's left is the actual `CalendarFeature` bug fix.
- The GIFT-Eval / finetuned-checkpoint question raised in #146 — whether published numbers were produced under the old encoding, and whether the shipped TabPFN-TS-3 checkpoint was finetuned against it — is a modelling call, not CI, and belongs in that thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrtVPCfgR3pYzW5H6x7kZD