### PR TITLE
Add example CI: smoke gate on PRs, scheduled full run

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -140,6 +140,56 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: uv run --no-sync pytest tests -ra
 
+  example_smoke:
+    name: Example smoke (CPU)
+    # A separate job (rather than part of test_compatibility) so the examples --
+    # which are comparatively slow -- run in parallel and don't block the normal
+    # test suite. Fast smoke gate: each example runs as a subprocess and fails
+    # only if it *errors*; one that doesn't finish within the timeout still passes,
+    # since we only assert it starts and runs without crashing. Running every
+    # example to completion (timeout = failure) is the job of the scheduled full
+    # run, test_examples_full.yml.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      # Highest resolution on purpose: examples are user-facing tutorials, so we
+      # test them against the deps a fresh install gets.
+      - name: Install the project
+        run: uv sync --all-extras --no-default-groups --group ci
+
+      - name: Restore TabPFN model cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: tabpfn-models-v1-${{ hashFiles('scripts/download_test_models.py', 'tabpfn_time_series/defaults.py') }}
+          restore-keys: |
+            tabpfn-models-v1-
+          enableCrossOsArchive: true
+
+      # -n auto runs the examples in parallel to keep wall-clock down. The
+      # per-example timeout is fixed in tests/test_examples.py. As in the unit
+      # suite, missing secrets on a fork PR become skips, not failures.
+      - name: Run example smoke tests
+        env:
+          TABPFN_CLIENT_API_KEY: ${{ secrets.TABPFN_CLIENT_API_KEY }}
+          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: uv run --no-sync pytest tests/test_examples.py --run-examples -n auto -ra
+
   build_verify:
     name: Build wheel + sdist
     runs-on: ubuntu-latest

--- a/.github/workflows/test_examples_full.yml
+++ b/.github/workflows/test_examples_full.yml
@@ -1,0 +1,124 @@
+name: Example full run
+run-name: "Example full run on ${{ github.ref_name }}"
+
+# Runs every example to completion at full size (EXAMPLE_FULL=1: a timeout is a
+# failure). Complements the per-PR smoke gate in pull_request.yml, which only
+# asserts that each example starts and runs without crashing.
+#
+# Runs on CPU, unlike the tabpfn-extensions equivalent: the examples here are
+# written to finish on CPU/MPS (see the docstring in
+# examples/explainability_electricity.py), so the scarce GPU runner tier would
+# buy nothing.
+#
+# Scheduled runs happen on `main`, where repository secrets are available, so
+# both the cloud-API and LOCAL-mode examples actually execute rather than skip.
+
+on:
+  schedule:
+    # Every other day, shortly after the weekly model cache refresh window.
+    - cron: "0 3 */2 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  example_full:
+    name: Example full run (CPU)
+    runs-on: ubuntu-latest
+    # Generous headroom below the 900s-per-example cap in tests/test_examples.py.
+    timeout-minutes: 60
+
+    env:
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      # Highest resolution on purpose: examples are user-facing tutorials, so we
+      # test them against the deps a fresh install gets.
+      - name: Install the project
+        run: uv sync --all-extras --no-default-groups --group ci
+
+      - name: Restore TabPFN model cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: tabpfn-models-v1-${{ hashFiles('scripts/download_test_models.py', 'tabpfn_time_series/defaults.py') }}
+          restore-keys: |
+            tabpfn-models-v1-
+          enableCrossOsArchive: true
+
+      # Sequential on purpose: parallel workers would distort per-example
+      # runtimes against the per-example timeout. `tee` captures output for the
+      # failure-issue body while still streaming to the log; pipefail preserves
+      # pytest's exit code through the pipe.
+      - name: Run examples to completion (full)
+        env:
+          EXAMPLE_FULL: "1"
+          TABPFN_CLIENT_API_KEY: ${{ secrets.TABPFN_CLIENT_API_KEY }}
+          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -o pipefail
+          uv run --no-sync pytest tests/test_examples.py --run-examples -v -ra 2>&1 \
+            | tee pytest_output.txt
+
+      # cancelled() covers the job-timeout case: exceeding timeout-minutes
+      # cancels the steps rather than failing them, so failure() alone would
+      # stay silent exactly when the run hangs.
+      - name: Open or update tracking issue on failure
+        if: failure() || cancelled()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs");
+            let failedLines = "(no FAILED lines parsed; see logs)";
+            try {
+              const text = fs.readFileSync("pytest_output.txt", "utf-8");
+              const lines = text.split("\n").filter(l => l.startsWith("FAILED "));
+              if (lines.length > 0) failedLines = lines.join("\n");
+            } catch (e) { /* output file missing -- fall through to default */ }
+
+            const title = "Scheduled example full run failed";
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: ["nightly-failure"],
+            });
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.runId}`;
+            const body =
+              `Run: ${runUrl}\n\n` +
+              `\`\`\`\n${failedLines}\n\`\`\`\n\n` +
+              `See logs for full output.`;
+            const existing = issues.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["nightly-failure"],
+              });
+            }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ exclude = ["docs", "gift_eval"]
 # tooling happens to paper over a gap.
 ci = [
     "pytest>=8.4.1",
+    # -n auto for the example smoke run.
+    "pytest-xdist>=3.6.0",
 ]
 dev = [
     {include-group = "ci"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,14 +25,30 @@ from pathlib import Path
 import pytest
 
 
-def _skip_reason_for_client() -> str | None:
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the opt-in flag for the example runner.
+
+    The scripts in `examples/` are user-facing demos, not unit tests: they
+    download data and fit real models, so they must not run as part of a plain
+    `pytest tests`. Without this flag `tests/test_examples.py` is still
+    collected but every case skips itself.
+    """
+    parser.addoption(
+        "--run-examples",
+        action="store_true",
+        default=False,
+        help="Run the example scripts in examples/ (see tests/test_examples.py).",
+    )
+
+
+def skip_reason_for_client() -> str | None:
     if os.getenv("TABPFN_CLIENT_API_KEY"):
         return None
     return "TABPFN_CLIENT_API_KEY is not set (expected on fork PRs)"
 
 
 @functools.lru_cache(maxsize=1)
-def _skip_reason_for_local() -> str | None:
+def skip_reason_for_local() -> str | None:
     from tabpfn.model_loading import prepend_cache_path
 
     from tabpfn_time_series.defaults import TABPFN_V3_TS_CHECKPOINT
@@ -49,8 +65,8 @@ def _skip_reason_for_local() -> str | None:
 
 
 _SKIP_REASON_BY_MARKER = {
-    "uses_tabpfn_client": _skip_reason_for_client,
-    "uses_tabpfn_local": _skip_reason_for_local,
+    "uses_tabpfn_client": skip_reason_for_client,
+    "uses_tabpfn_local": skip_reason_for_local,
 }
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,150 @@
+"""Run the example files in ``examples/`` and check they work.
+
+Each example is executed as a subprocess with a fixed per-example timeout.
+There are two run modes:
+
+* **Smoke** (default): an example that *errors* fails the test; one that simply
+  doesn't finish in time *passes* -- we only assert it starts and runs without
+  crashing. This is the fast, cheap per-PR guard against broken example scripts
+  and import errors.
+* **Full** (``EXAMPLE_FULL=1``): every example must run *to completion*, and a
+  timeout is a failure -- exactly as a user would experience it. This is the
+  scheduled GPU full run. The switch is an environment variable rather than a
+  pytest CLI option so that command-line arguments cannot flip the pass/fail
+  semantics of a run.
+
+An example is **skipped** (not failed) when the credentials or weights it needs
+aren't available -- the same rule the unit suite applies via the
+``uses_tabpfn_client`` / ``uses_tabpfn_local`` markers, so fork PRs (which get
+no secrets) report honest skips instead of red builds.
+
+Usage:
+    uv run --no-sync pytest tests/test_examples.py --run-examples
+    EXAMPLE_FULL=1 uv run --no-sync pytest tests/test_examples.py --run-examples
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from conftest import skip_reason_for_client, skip_reason_for_local
+
+# Full run: every example runs to completion; a timeout is a failure. Used by
+# the scheduled GPU full run. In the default smoke mode a timeout still passes
+# -- we only assert the example starts and runs without crashing.
+FULL_RUN = os.environ.get("EXAMPLE_FULL", "0") == "1"
+
+# Per-example timeout. The smoke budget is short since a timeout passes anyway;
+# the full-run budget is sized so it only bites on genuine hangs. The slowest
+# example (explainability_electricity) fits a TabPFN context per rolling window
+# and downloads a parquet from S3 first.
+EXAMPLE_TIMEOUT_SECONDS = 900 if FULL_RUN else 120
+
+# Files under examples/ that are not themselves examples: shared helpers the
+# example scripts import. Running them as a script is a no-op at best.
+NOT_EXAMPLES = {"common.py"}
+
+# Examples that call the TabPFN cloud API and so need TABPFN_CLIENT_API_KEY.
+REQUIRES_CLIENT = {"tabpfn_family_model_as_backbone.py"}
+
+# Examples that run a checkpoint locally, so they need the weights on disk (or
+# a TABPFN_TOKEN to fetch them).
+REQUIRES_LOCAL = {"explainability_electricity.py"}
+
+
+def get_example_files() -> list[dict]:
+    """Discover example files and attach the metadata the runner needs."""
+    package_root = Path(__file__).parent.parent
+    examples_dir = package_root / "examples"
+
+    files = []
+    for file_path in sorted(examples_dir.glob("**/*.py")):
+        name = file_path.name
+        if name in NOT_EXAMPLES:
+            continue
+        files.append(
+            {
+                "path": file_path,
+                "name": name,
+                "requires_client": name in REQUIRES_CLIENT,
+                "requires_local": name in REQUIRES_LOCAL,
+            },
+        )
+    return files
+
+
+@pytest.mark.parametrize(
+    "example_file",
+    [pytest.param(f, id=f["name"]) for f in get_example_files()],
+)
+def test_example(request, example_file):
+    """Run a single example file as a subprocess and check the outcome."""
+    name = example_file["name"]
+    path = example_file["path"]
+
+    if not request.config.getoption("--run-examples"):
+        pytest.skip(f"Skipping {name} since --run-examples not set")
+
+    if example_file["requires_client"]:
+        reason = skip_reason_for_client()
+        if reason is not None:
+            pytest.skip(f"Example {name} needs the TabPFN cloud API: {reason}")
+
+    if example_file["requires_local"]:
+        reason = skip_reason_for_local()
+        if reason is not None:
+            pytest.skip(f"Example {name} runs a local checkpoint: {reason}")
+
+    # Examples are top-to-bottom scripts; run each in its own process so a hang
+    # can be killed cleanly and state never leaks between examples. They import
+    # sibling helpers (examples/common.py) by plain module name, so the working
+    # directory has to be examples/.
+    env = dict(os.environ)
+    if FULL_RUN:
+        # Full size, exactly as a user would run the example. Stripped rather
+        # than inherited so a stray setting can't quietly shrink what the full
+        # run verifies.
+        env.pop("FAST_TEST_MODE", None)
+    else:
+        # Shrink the workload where an example supports it. None do today; the
+        # smoke budget is what actually bounds runtime here.
+        env["FAST_TEST_MODE"] = "1"
+    # Headless plotting: an example calling plt.show() must never block on a GUI
+    # window (on a machine with a display, the interactive backend blocks until
+    # the window is closed -- fatal in full-run mode, where that reads as a
+    # timeout).
+    env.setdefault("MPLBACKEND", "Agg")
+
+    try:
+        proc = subprocess.run(  # noqa: S603 - trusted, repo-local example scripts
+            [sys.executable, str(path)],
+            cwd=str(path.parent),
+            env=env,
+            timeout=EXAMPLE_TIMEOUT_SECONDS,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        if FULL_RUN:
+            pytest.fail(
+                f"Example {name} did not complete within "
+                f"{EXAMPLE_TIMEOUT_SECONDS}s (full run: a timeout is a failure)",
+            )
+        # Not a failure: the example started and ran without crashing, which is
+        # all the smoke gate asserts. Completion is checked by the full run.
+        print(
+            f"{name}: ran {EXAMPLE_TIMEOUT_SECONDS}s without error "
+            f"(smoke mode; completion not verified)",
+        )
+        return
+
+    if proc.returncode != 0:
+        output = (proc.stdout or b"").decode("utf-8", "replace")
+        tail = "\n".join(output.strip().splitlines()[-100:])
+        pytest.fail(f"Example {name} exited with code {proc.returncode}:\n{tail}")

--- a/uv.lock
+++ b/uv.lock
@@ -1399,6 +1399,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4506,6 +4515,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -5891,6 +5913,7 @@ explainability = [
 [package.dev-dependencies]
 ci = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 dev = [
     { name = "build" },
@@ -5900,6 +5923,7 @@ dev = [
     { name = "jupyter" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "submitit" },
     { name = "tabpfn-time-series", extra = ["benchmarking", "explainability"] },
@@ -5928,7 +5952,10 @@ requires-dist = [
 provides-extras = ["benchmarking", "explainability"]
 
 [package.metadata.requires-dev]
-ci = [{ name = "pytest", specifier = ">=8.4.1" }]
+ci = [
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
+]
 dev = [
     { name = "build" },
     { name = "hatch" },
@@ -5937,6 +5964,7 @@ dev = [
     { name = "jupyter" },
     { name = "pre-commit" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = "~=0.12.0" },
     { name = "submitit", specifier = ">=1.5.2" },
     { name = "tabpfn-time-series", extras = ["benchmarking", "explainability"] },


### PR DESCRIPTION
**Stack 4/5** — base: #149

Ports tabpfn-extensions' example testing. The scripts in `examples/` are user-facing tutorials that nothing currently exercises, so they can rot silently between releases; this catches that.

`tests/test_examples.py` runs each example as a subprocess in two modes:

| Mode | Where | Semantics |
|---|---|---|
| **Smoke** | `example_smoke` job, every PR | An example that *errors* fails. One that merely runs past the 120s budget **passes** — we only assert it starts and runs without crashing. |
| **Full** (`EXAMPLE_FULL=1`) | `test_examples_full.yml`, scheduled | Every example must run **to completion** within 900s; a timeout is a failure. Catches an example that technically starts but never finishes. |

### Adapted to this repo rather than copied
- Discovery skips `examples/common.py` — it's a shared helper the examples import, not an example.
- Skips are driven by the **same credential/weight checks the unit suite already uses**, now exported from `tests/conftest.py` as `skip_reason_for_client` / `skip_reason_for_local`. So `tabpfn_family_model_as_backbone.py` (cloud API) and `explainability_electricity.py` (LOCAL checkpoint) skip with a readable reason on fork PRs instead of failing.
- The scheduled full run uses **`ubuntu-latest`, not the GPU tier** extensions uses. These examples are written to finish on CPU/MPS, so a GPU runner would buy nothing.
- **No `examples` dependency group**: everything the examples need (matplotlib/shapiq via the `explainability` extra, sklearn via `tabpfn`) is already installed by `--all-extras`.

### Verified locally
```
12 workers [3 items]
ss.                                                     [100%]
SKIPPED Example tabpfn_family_model_as_backbone.py needs the TabPFN cloud API: TABPFN_CLIENT_API_KEY is not set (expected on fork PRs)
SKIPPED Example explainability_electricity.py runs a local checkpoint: ...ckpt is not in the model cache and TABPFN_TOKEN is not set (expected on fork PRs)
1 passed, 2 skipped in 8.30s
```

The extensions `FAST_TEST_MODE` convention is carried through, though no example reads it yet — today the timeout is what bounds smoke runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5CuWWCMZ96DYxU5Jay8ad