### PR TITLE
Disable github automatic reviewer assignment.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @PriorLabs/opensource-review-team


### PR DESCRIPTION
https://github.com/PriorLabs/tabpfn-time-series/pull/148 copied assign-pr-reviewer.yml, which automatically assigns reviewers to external PRs. Thus we now longer need the CODEOWNERS approach, which is annoying because it also assigns reviewers to internal PRs.