### PR TITLE
Always run tests that rely on a local model.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
     "uses_tabpfn_client: These tests require a TabPFN API key.",
-    "uses_tabpfn_local: These tests require a local TabPFN model.",
 ]
 
 [tool.changelog-bot.towncrier_changelog]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,12 @@
-"""Skip integration tests whose credentials / model weights aren't available.
+"""Skip integration tests whose credentials aren't available.
 
-Two markers gate the integration tests (declared in `pyproject.toml`):
-
-* `uses_tabpfn_client` needs `TABPFN_CLIENT_API_KEY` — a cloud call, so there is
-  no offline substitute.
-* `uses_tabpfn_local` needs the TabPFN checkpoint on disk. That is satisfied
-  either by a checkpoint already in the model cache (CI restores one that `main`
-  populated — see `.github/workflows/cache-models.yml`) or by a `TABPFN_TOKEN`
-  to download it on the fly.
-
-Fork PRs get neither secret, so without this hook the whole integration suite
-fails there with `TabPFNLicenseError` / missing-key assertions on changes that
-have nothing to do with TabPFN. Skipping keeps the signal honest for external
-contributors while internal PRs — which do get the secrets — still run
-everything.
+The `uses_tabpfn_client` marker indicates tests that call the client, thus require a
+`TABPFN_CLIENT_API_KEY` to work. We skip these tests, if the secret isn't present.
 """
 
 from __future__ import annotations
 
-import functools
 import os
-from pathlib import Path
 
 import pytest
 
@@ -41,41 +27,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def skip_reason_for_client() -> str | None:
+def should_skip_client_tests() -> str | None:
     if os.getenv("TABPFN_CLIENT_API_KEY"):
         return None
     return "TABPFN_CLIENT_API_KEY is not set (expected on fork PRs)"
 
 
-@functools.lru_cache(maxsize=1)
-def skip_reason_for_local() -> str | None:
-    from tabpfn.model_loading import prepend_cache_path
-
-    from tabpfn_time_series.defaults import TABPFN_V3_TS_CHECKPOINT
-
-    checkpoint = Path(prepend_cache_path(TABPFN_V3_TS_CHECKPOINT))
-    if checkpoint.exists():
-        return None
-    if os.getenv("TABPFN_TOKEN"):
-        return None
-    return (
-        f"{checkpoint.name} is not in the model cache ({checkpoint.parent}) and "
-        "TABPFN_TOKEN is not set to download it (expected on fork PRs)"
-    )
-
-
-_SKIP_REASON_BY_MARKER = {
-    "uses_tabpfn_client": skip_reason_for_client,
-    "uses_tabpfn_local": skip_reason_for_local,
-}
-
-
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
-        for marker, skip_reason in _SKIP_REASON_BY_MARKER.items():
-            if item.get_closest_marker(marker) is None:
-                continue
-            reason = skip_reason()
-            if reason is not None:
-                item.add_marker(pytest.mark.skip(reason=reason))
-                break
+        if item.get_closest_marker("uses_tabpfn_client") is None:
+            continue
+        reason = should_skip_client_tests()
+        if reason is not None:
+            item.add_marker(pytest.mark.skip(reason=reason))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,10 +13,10 @@ There are two run modes:
   pytest CLI option so that command-line arguments cannot flip the pass/fail
   semantics of a run.
 
-An example is **skipped** (not failed) when the credentials or weights it needs
-aren't available -- the same rule the unit suite applies via the
-``uses_tabpfn_client`` / ``uses_tabpfn_local`` markers, so fork PRs (which get
-no secrets) report honest skips instead of red builds.
+An example is **skipped** (not failed) when the credentials it needs aren't
+available -- the same rule the unit suite applies via the ``uses_tabpfn_client``
+marker, so fork PRs (which get no secrets) report honest skips instead of red
+builds.
 
 Usage:
     uv run --no-sync pytest tests/test_examples.py --run-examples
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import pytest
 
-from conftest import skip_reason_for_client, skip_reason_for_local
+from conftest import should_skip_client_tests
 
 # Full run: every example runs to completion; a timeout is a failure. Used by
 # the scheduled GPU full run. In the default smoke mode a timeout still passes
@@ -52,10 +52,6 @@ NOT_EXAMPLES = {"common.py"}
 # Examples that call the TabPFN cloud API and so need TABPFN_CLIENT_API_KEY.
 REQUIRES_CLIENT = {"tabpfn_family_model_as_backbone.py"}
 
-# Examples that run a checkpoint locally, so they need the weights on disk (or
-# a TABPFN_TOKEN to fetch them).
-REQUIRES_LOCAL = {"explainability_electricity.py"}
-
 
 def get_example_files() -> list[dict]:
     """Discover example files and attach the metadata the runner needs."""
@@ -72,7 +68,6 @@ def get_example_files() -> list[dict]:
                 "path": file_path,
                 "name": name,
                 "requires_client": name in REQUIRES_CLIENT,
-                "requires_local": name in REQUIRES_LOCAL,
             },
         )
     return files
@@ -91,14 +86,9 @@ def test_example(request, example_file):
         pytest.skip(f"Skipping {name} since --run-examples not set")
 
     if example_file["requires_client"]:
-        reason = skip_reason_for_client()
+        reason = should_skip_client_tests()
         if reason is not None:
             pytest.skip(f"Example {name} needs the TabPFN cloud API: {reason}")
-
-    if example_file["requires_local"]:
-        reason = skip_reason_for_local()
-        if reason is not None:
-            pytest.skip(f"Example {name} runs a local checkpoint: {reason}")
 
     # Examples are top-to-bottom scripts; run each in its own process so a hang
     # can be killed cleanly and state never leaks between examples. They import

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -259,7 +259,6 @@ def test_window_collapse_warns(explainer_factory):
         )
 
 
-@pytest.mark.uses_tabpfn_local
 def test_integration_local_tabpfn():
     """End-to-end against a local TabPFN model on a tiny series."""
     df = make_series(n=180)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -80,7 +80,6 @@ def create_toy_fev_task() -> fev.Task:
 
 
 class TestTabPFNTSPipeline:
-    @pytest.mark.uses_tabpfn_local
     def test_predict_local_mode(self):
         """Test predict method with local TabPFN mode."""
         context_tsdf = create_context_tsdf()
@@ -108,7 +107,6 @@ class TestTabPFNTSPipeline:
         assert len(result) == 6
         assert "target" in result.columns
 
-    @pytest.mark.uses_tabpfn_local
     def test_predict_df_with_prediction_length(self):
         """Test predict_df using prediction_length parameter."""
         context_df = create_context_df()
@@ -119,7 +117,6 @@ class TestTabPFNTSPipeline:
         assert result is not None
         assert len(result) == 6  # 2 items * 3 prediction steps
 
-    @pytest.mark.uses_tabpfn_local
     def test_predict_df_with_future_df(self):
         """Test predict_df using explicit future_df."""
         context_df = create_context_df()
@@ -137,7 +134,6 @@ class TestTabPFNTSPipeline:
         assert result is not None
         assert len(result) == 6
 
-    @pytest.mark.uses_tabpfn_local
     def test_predict_df_single_series(self):
         """Test predict_df with a single time series (no item_id column)."""
         dates = pd.date_range(start="2023-01-01", periods=10, freq="D")
@@ -175,7 +171,6 @@ class TestTabPFNTSPipeline:
         with pytest.raises(ValueError, match="exactly one"):
             pipeline.predict_df(context_df)
 
-    @pytest.mark.uses_tabpfn_local
     def test_custom_quantiles(self):
         """Test that custom quantiles are returned in the result."""
         context_tsdf = create_context_tsdf()
@@ -188,7 +183,6 @@ class TestTabPFNTSPipeline:
         for q in custom_quantiles:
             assert q in result.columns, f"Quantile {q} not in result columns"
 
-    @pytest.mark.uses_tabpfn_local
     def test_predict_fev(self):
         """Test predict_fev method with a real fev task."""
         task = create_toy_fev_task()

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -85,7 +85,6 @@ class TestTabPFNTimeSeriesPredictor:
 
         assert result is not None
 
-    @pytest.mark.uses_tabpfn_local
     def test_local_mode(self):
         """Test that predict method calls the worker's predict method"""
         train_tsdf, test_tsdf = create_test_data()
@@ -98,7 +97,7 @@ class TestTimeSeriesPredictor:
     @pytest.mark.parametrize(
         "tabpfn_class",
         [
-            pytest.param(tabpfn.TabPFNRegressor, marks=pytest.mark.uses_tabpfn_local),
+            pytest.param(tabpfn.TabPFNRegressor),
             pytest.param(
                 tabpfn_client.TabPFNRegressor, marks=pytest.mark.uses_tabpfn_client
             ),
@@ -149,7 +148,6 @@ class TestTimeSeriesPredictor:
                 lambda: TabPFNTimeSeriesPredictor(tabpfn_mode=TabPFNMode.LOCAL),
                 True,  # TabPFN computes real quantiles
                 id="tabpfn_local",
-                marks=pytest.mark.uses_tabpfn_local,
             ),
             pytest.param(
                 lambda: (
@@ -203,7 +201,6 @@ class TestTimeSeriesPredictor:
                 [],
                 False,
                 id="tabpfn_local-empty",
-                marks=pytest.mark.uses_tabpfn_local,
             ),
             # Unsorted quantiles - should work
             pytest.param(
@@ -222,7 +219,6 @@ class TestTimeSeriesPredictor:
                 [0.1, 0.5, 0.9],
                 False,
                 id="tabpfn_local-unsorted",
-                marks=pytest.mark.uses_tabpfn_local,
             ),
             # Duplicate quantiles - should work
             pytest.param(
@@ -241,7 +237,6 @@ class TestTimeSeriesPredictor:
                 [0.5, 0.9],
                 False,
                 id="tabpfn_local-duplicates",
-                marks=pytest.mark.uses_tabpfn_local,
             ),
             # Invalid quantiles - should raise
             pytest.param(
@@ -250,7 +245,6 @@ class TestTimeSeriesPredictor:
                 None,
                 True,
                 id="tabpfn_local-invalid",
-                marks=pytest.mark.uses_tabpfn_local,
             ),
         ],
     )


### PR DESCRIPTION
I get that we might want to skip the tests that use the client, but I
think we should always run the ones that use a local model, now we've
fixed running them in forks.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>